### PR TITLE
Set Security Guild as codeowner of CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,4 @@
 
 CODEOWNERS                        @coopnorge/security-guild
+
+.github/workflows/security-* @coopnorge/security-guild


### PR DESCRIPTION

Closes: coopnorge/engineering-issues#133